### PR TITLE
Backend for adding users to organisations (with permissions)

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,7 @@
                  [org.postgresql/postgresql "42.2.5"]
                  [org.clojure/java.jdbc "0.7.9"]
                  [honeysql "0.9.4"]
-                 [toucan "1.12.0"]
+                 [nilenso/honeysql-postgres "0.2.6"]
                  [ragtime "0.8.0"]
 
                  [ring/ring-core "1.7.1"]

--- a/resources/migrations/001-create-users.edn
+++ b/resources/migrations/001-create-users.edn
@@ -1,0 +1,9 @@
+;; resources/migrations/001-create-users.edn
+{:up   ["CREATE TABLE users (
+           id         SERIAL PRIMARY KEY,
+           email      TEXT NOT NULL UNIQUE,
+           nickname   TEXT NOT NULL,
+           name       TEXT,
+           password   TEXT NOT NULL,
+           created_at TIMESTAMP DEFAULT now());"]
+ :down ["DROP TABLE users;"]}

--- a/resources/migrations/002-create-organisations.edn
+++ b/resources/migrations/002-create-organisations.edn
@@ -1,0 +1,7 @@
+;; resources/migrations/002-create-organisations.edn
+{:up   ["CREATE TABLE organisations (
+           id         SERIAL PRIMARY KEY,
+           name       TEXT NOT NULL,
+           color      TEXT,
+           created_at TIMESTAMP DEFAULT now());"]
+ :down ["DROP TABLE organisations;"]}

--- a/resources/migrations/003-create-organisation-permissions.edn
+++ b/resources/migrations/003-create-organisation-permissions.edn
@@ -1,0 +1,9 @@
+;; resources/migrations/003-create-organisation-permissions.edn
+{:up ["CREATE TYPE permission AS ENUM ('none', 'owner', 'member')";
+      "CREATE TABLE organisation_permissions (
+       id         SERIAL PRIMARY KEY,
+       org_id     INTEGER REFERENCES organisations ON DELETE CASCADE,
+       user_id    INTEGER REFERENCES users ON DELETE CASCADE,
+       permission permission DEFAULT 'none');"]
+ :down ["DROP TABLE organisation_permissions;"
+        "DROP TYPE permission;"]}

--- a/resources/migrations/004-add-permission-constraint.edn
+++ b/resources/migrations/004-add-permission-constraint.edn
@@ -1,0 +1,6 @@
+;; resources/migrations/004-add-permission-constraint.edn
+{:up   ["ALTER TABLE organisation_permissions
+         ADD CONSTRAINT user_org_unique
+         UNIQUE (user_id, org_id);"]
+ :down ["ALTER TABLE organisation_permissions
+         DROP CONSTRAINT user_org_unique;"]}

--- a/resources/migrations/organisations.edn
+++ b/resources/migrations/organisations.edn
@@ -1,6 +1,0 @@
-;; resources/migrations/001-organisations.edn
-{:up   ["CREATE TABLE organisations(id serial primary key,
-              name text NOT NULL,
-              color text,
-              created_at timestamp DEFAULT now());"]
- :down ["DROP TABLE organisations;"]}

--- a/resources/migrations/users.edn
+++ b/resources/migrations/users.edn
@@ -1,8 +1,0 @@
-;; resources/migrations/001-users.edn
-{:up   ["CREATE TABLE users(id serial primary key,
-              email text NOT NULL unique,
-              nickname text NOT NULL,
-              name text,
-              password text NOT NULL,
-              created_at timestamp DEFAULT now());"]
- :down ["DROP TABLE users;"]}

--- a/src/clj/villagebook/auth/core.clj
+++ b/src/clj/villagebook/auth/core.clj
@@ -1,6 +1,7 @@
-(ns villagebook.auth.backend
+(ns villagebook.auth.core
   (:require [buddy.auth.backends.token :as backend]
-            [buddy.auth.protocols :as proto]))
+            [buddy.auth.protocols :as proto]
+            [villagebook.config :as config]))
 
 (defn custom-backend
   "Reads token from cookies (if present) and passes it to buddy-auth's jws-backend."

--- a/src/clj/villagebook/auth/core.clj
+++ b/src/clj/villagebook/auth/core.clj
@@ -1,7 +1,6 @@
 (ns villagebook.auth.core
   (:require [buddy.auth.backends.token :as backend]
-            [buddy.auth.protocols :as proto]
-            [villagebook.config :as config]))
+            [buddy.auth.protocols :as proto]))
 
 (defn custom-backend
   "Reads token from cookies (if present) and passes it to buddy-auth's jws-backend."

--- a/src/clj/villagebook/config.clj
+++ b/src/clj/villagebook/config.clj
@@ -1,6 +1,5 @@
 (ns villagebook.config
-  (:require [villagebook.auth.backend :as backend]
-            [aero.core :refer (read-config)]
+  (:require [aero.core :refer (read-config)]
             [clojure.java.io :as io]))
 
 (def config (atom nil))
@@ -23,11 +22,6 @@
   []
   (:jwt-secret @config))
 
-(defn auth-backend-config
+(defn auth-config
   []
   {:secret (jwt-secret)})
-
-;; Setup auth middleware
-(defn auth-backend
-  []
-  (backend/custom-backend auth-backend-config))

--- a/src/clj/villagebook/organisation/db.clj
+++ b/src/clj/villagebook/organisation/db.clj
@@ -2,7 +2,9 @@
   (:require [villagebook.config :as config]
             [clojure.java.jdbc :as jdbc]
             [honeysql.core :as sql]
-            [honeysql.helpers :as h]))
+            [honeysql.helpers :as h]
+            [honeysql-postgres.format :refer :all]
+            [honeysql-postgres.helpers :as psqlh]))
 
 (defn get-by-id [id]
   (-> (jdbc/query (config/db-spec) (-> (h/select :*)
@@ -11,6 +13,18 @@
                                      (sql/format)))
       first))
 
-(defn create [{:keys [name color]}]
+(defn create! [{:keys [name color]}]
   (-> (jdbc/insert! (config/db-spec) :organisations {:name name :color color})
       first))
+
+(defn add-user-as!
+  "Adds a user to the organisation with a permission"
+  [org-id user-id permission]
+  (jdbc/db-do-prepared-return-keys (config/db-spec)
+                                   (-> (h/insert-into :organisation_permissions)
+                                       (h/values [{:org_id     org-id
+                                                   :user_id    user-id
+                                                   :permission (sql/inline
+                                                                (str "'"permission"'::permission"))}])
+                                     (psqlh/returning :*)
+                                     (sql/format))))

--- a/src/clj/villagebook/organisation/db.clj
+++ b/src/clj/villagebook/organisation/db.clj
@@ -7,7 +7,7 @@
             [honeysql-postgres.helpers :as psqlh]
             [villagebook.organisation.spec :as spec]))
 
-(defn make-postgres-enum
+(defn- make-postgres-enum
   [string]
   (str "'" (name string) "'::permission"))
 

--- a/src/clj/villagebook/organisation/db.clj
+++ b/src/clj/villagebook/organisation/db.clj
@@ -6,13 +6,6 @@
             [honeysql-postgres.format :refer :all]
             [honeysql-postgres.helpers :as psqlh]))
 
-(defn get-by-id [id]
-  (-> (jdbc/query (config/db-spec) (-> (h/select :*)
-                                     (h/from :organisations)
-                                     (h/where [:= :id id])
-                                     (sql/format)))
-      first))
-
 (defn create! [{:keys [name color]}]
   (-> (jdbc/insert! (config/db-spec) :organisations {:name name :color color})
       first))
@@ -28,3 +21,23 @@
                                                                 (str "'"permission"'::permission"))}])
                                      (psqlh/returning :*)
                                      (sql/format))))
+
+(defn retrieve
+  ([]
+   "Returns a list of all organisations"
+    (jdbc/query (config/db-spec) (-> (h/select :*)
+                                     (h/from :organisations)
+                                     (sql/format))))
+  ([id]
+   "Returns an organisation by id"
+   (jdbc/get-by-id (config/db-spec) :organisations id)))
+
+(defn retrieve-by-user
+  ([user-id]
+   "Returns a list of organisations belonging to a user with permission on each."
+   (jdbc/query (config/db-spec) (-> (h/select :*)
+                                    (h/from :organisations)
+                                    (h/join :organisation_permissions
+                                            [:= :organisations.id :organisation_permissions.org_id])
+                                    (h/where [:= :user-id user-id])
+                                    (sql/format)))))

--- a/src/clj/villagebook/organisation/handlers.clj
+++ b/src/clj/villagebook/organisation/handlers.clj
@@ -2,6 +2,7 @@
   (:require [ring.util.response :as res]
             [clojure.edn :as edn]
             [villagebook.organisation.db :as db]
+            [villagebook.organisation.models :as models]
             [villagebook.organisation.spec :as organisation-spec]
             [clojure.spec.alpha :as s]))
 
@@ -9,9 +10,10 @@
   [request]
   (let [{name  :name
          color :color
-         :as   orgdata} (:params request)]
+         :as   orgdata} (:params request)
+        {user-id :id}   (:identity request)]
     (if (organisation-spec/valid-organisation-details? orgdata)
-      (let [neworg (db/create! orgdata)]
+      (let [{neworg :success} (models/create! orgdata user-id)]
         (-> (res/response neworg)
             (res/status 201)))
       (res/bad-request "Invalid request."))))

--- a/src/clj/villagebook/organisation/handlers.clj
+++ b/src/clj/villagebook/organisation/handlers.clj
@@ -16,10 +16,10 @@
             (res/status 201)))
       (res/bad-request "Invalid request."))))
 
-(defn get-by-id
+(defn retrieve
   [request]
   (let [id (edn/read-string (get-in request [:params :id]))
-        org (db/get-by-id id)]
+        org (db/retrieve id)]
     (if id
       (if org
         (res/response org)

--- a/src/clj/villagebook/organisation/handlers.clj
+++ b/src/clj/villagebook/organisation/handlers.clj
@@ -18,14 +18,18 @@
             (res/status 201)))
       (res/bad-request "Invalid request."))))
 
+(defn- retrieve-from-model
+  [id]
+  (let [message        (models/retrieve 55)
+        {org :success}  message
+        {error :error} message]
+    (if org
+      (res/response org)
+      (res/not-found error))))
+
 (defn retrieve
   [request]
   (let [id (edn/read-string (get-in request [:params :id]))]
     (if (s/valid? ::organisation-spec/id id)
-      (let [message        (models/retrieve id)
-            {org :success} message
-            {error :error} message]
-        (if org
-          (res/response org)
-          (res/not-found error)))
+      (retrieve-from-model id)
       (res/bad-request "Invalid request."))))

--- a/src/clj/villagebook/organisation/handlers.clj
+++ b/src/clj/villagebook/organisation/handlers.clj
@@ -20,12 +20,12 @@
 
 (defn retrieve
   [request]
-  (let [id             (edn/read-string (get-in request [:params :id]))
-        message        (models/retrieve id)
-        {org :success} message
-        {error :error} message]
-    (if id
-      (if org
-        (res/response org)
-        (res/not-found error))
+  (let [id (edn/read-string (get-in request [:params :id]))]
+    (if (s/valid? ::organisation-spec/id id)
+      (let [message        (models/retrieve id)
+            {org :success} message
+            {error :error} message]
+        (if org
+          (res/response org)
+          (res/not-found error)))
       (res/bad-request "Invalid request."))))

--- a/src/clj/villagebook/organisation/handlers.clj
+++ b/src/clj/villagebook/organisation/handlers.clj
@@ -20,10 +20,12 @@
 
 (defn retrieve
   [request]
-  (let [id (edn/read-string (get-in request [:params :id]))
-        org (db/retrieve id)]
+  (let [id             (edn/read-string (get-in request [:params :id]))
+        message        (models/retrieve id)
+        {org :success} message
+        {error :error} message]
     (if id
       (if org
         (res/response org)
-        (res/not-found "Organisation not found."))
+        (res/not-found error))
       (res/bad-request "Invalid request."))))

--- a/src/clj/villagebook/organisation/handlers.clj
+++ b/src/clj/villagebook/organisation/handlers.clj
@@ -5,13 +5,13 @@
             [villagebook.organisation.spec :as organisation-spec]
             [clojure.spec.alpha :as s]))
 
-(defn create-organisation
+(defn create!
   [request]
-  (let [{name :name
+  (let [{name  :name
          color :color
-         :as orgdata} (:params request)]
+         :as   orgdata} (:params request)]
     (if (organisation-spec/valid-organisation-details? orgdata)
-      (let [neworg (db/create orgdata)]
+      (let [neworg (db/create! orgdata)]
         (-> (res/response neworg)
             (res/status 201)))
       (res/bad-request "Invalid request."))))

--- a/src/clj/villagebook/organisation/models.clj
+++ b/src/clj/villagebook/organisation/models.clj
@@ -1,0 +1,11 @@
+(ns villagebook.organisation.models
+  (:require [villagebook.organisation.db :as db]
+            [villagebook.factory :as factory]))
+
+(defonce DEFAULT_PERMISSION "owner")
+
+(defn create!
+  [orgdata user-id]
+  (let [{org-id :id :as org} (db/create! orgdata)
+        permission           (db/add-user-as! org-id user-id DEFAULT_PERMISSION)]
+    {:success org}))

--- a/src/clj/villagebook/organisation/models.clj
+++ b/src/clj/villagebook/organisation/models.clj
@@ -2,7 +2,7 @@
   (:require [villagebook.organisation.db :as db]
             [villagebook.factory :as factory]))
 
-(defonce DEFAULT_PERMISSION "owner")
+(defonce DEFAULT_PERMISSION :owner)
 
 (defn create!
   [orgdata user-id]

--- a/src/clj/villagebook/organisation/models.clj
+++ b/src/clj/villagebook/organisation/models.clj
@@ -9,3 +9,10 @@
   (let [{org-id :id :as org} (db/create! orgdata)
         permission           (db/add-user-as! org-id user-id DEFAULT_PERMISSION)]
     {:success org}))
+
+(defn retrieve
+  [id]
+  (let [org (db/retrieve id)]
+    (if org
+      {:success org}
+      {:error "Organisation not found"})))

--- a/src/clj/villagebook/organisation/spec.clj
+++ b/src/clj/villagebook/organisation/spec.clj
@@ -3,7 +3,14 @@
             [clojure.spec.alpha :as s]))
 
 (s/def ::organisation-details (s/keys :req-un [::name]))
+(def permissions #{:owner :member :none})
 
 (defn valid-organisation-details?
   [organisation]
   (s/valid? ::organisation-details organisation))
+
+(defn valid-permission?
+  [permission]
+  (if (s/valid? permissions permission)
+    permission
+    :none))

--- a/src/clj/villagebook/organisation/spec.clj
+++ b/src/clj/villagebook/organisation/spec.clj
@@ -2,6 +2,7 @@
   (:require [villagebook.utils :refer [required]]
             [clojure.spec.alpha :as s]))
 
+(s/def ::id (s/and int? #(> % 0)))
 (s/def ::organisation-details (s/keys :req-un [::name]))
 (def permissions #{:owner :member :none})
 

--- a/src/clj/villagebook/routes.clj
+++ b/src/clj/villagebook/routes.clj
@@ -10,8 +10,9 @@
 
 (def apiroutes
   {"organisations" {["/" :id] {:get (with-auth org/get-by-id)}
-                    :post     (with-auth org/create-organisation)}
+                    :post     (with-auth org/create!)}
    "user"          {:get (with-auth user/retrieve)}})
+
 
 ;; Setup routes
 (def routes

--- a/src/clj/villagebook/routes.clj
+++ b/src/clj/villagebook/routes.clj
@@ -3,7 +3,7 @@
             [buddy.auth.middleware :refer [wrap-authorization]]
 
             [villagebook.middleware :refer [with-auth]]
-            [villagebook.auth.handlers :as auth]
+            [villagebook.user.handlers :as user]
             [villagebook.organisation.handlers :as org]
             [villagebook.handlers :refer [api-handler frontend-handler]]
             [villagebook.config :as config]))
@@ -11,12 +11,12 @@
 (def apiroutes
   {"organisations" {["/" :id] {:get (with-auth org/get-by-id)}
                     :post     (with-auth org/create-organisation)}
-   "user"          {:get (with-auth auth/retrieve)}})
+   "user"          {:get (with-auth user/retrieve)}})
 
 ;; Setup routes
 (def routes
   ["/" {"assets" (resources {:prefix "public/assets/"})
         "api/"   apiroutes
-        "signup" {:post auth/signup}
-        "login"  {:post auth/login}
+        "signup" {:post user/signup}
+        "login"  {:post user/login}
         true     frontend-handler}])

--- a/src/clj/villagebook/routes.clj
+++ b/src/clj/villagebook/routes.clj
@@ -9,7 +9,7 @@
             [villagebook.config :as config]))
 
 (def apiroutes
-  {"organisations" {["/" :id] {:get (with-auth org/get-by-id)}
+  {"organisations" {["/" :id] {:get (with-auth org/retrieve)}
                     :post     (with-auth org/create!)}
    "user"          {:get (with-auth user/retrieve)}})
 

--- a/src/clj/villagebook/user/db.clj
+++ b/src/clj/villagebook/user/db.clj
@@ -1,4 +1,4 @@
-(ns villagebook.auth.db
+(ns villagebook.user.db
   (:require [clojure.java.jdbc :as jdbc]
             [honeysql.core :as sql]
             [honeysql.helpers :as honey]

--- a/src/clj/villagebook/user/handlers.clj
+++ b/src/clj/villagebook/user/handlers.clj
@@ -42,7 +42,7 @@
 
 (defn retrieve
   [{identity :identity :as request}]
-  (if-let [user (:user identity)]
+  (if-let [user (:email identity)]
     (if-let [userdata (models/get-by-email user)]
       (res/response userdata)
       (-> (res/response "Something went wrong.")

--- a/src/clj/villagebook/user/handlers.clj
+++ b/src/clj/villagebook/user/handlers.clj
@@ -1,17 +1,17 @@
-(ns villagebook.auth.handlers
+(ns villagebook.user.handlers
   (:require [ring.util.response :as res]
             [buddy.hashers :as hasher]
             [buddy.auth :refer [authenticated? throw-unauthorized]]
             [buddy.sign.jwt :as jwt]
 
-            [villagebook.auth.db :as db]
-            [villagebook.auth.models :as models]
+            [villagebook.user.db :as db]
+            [villagebook.user.models :as models]
             [villagebook.config :as config]
-            [villagebook.auth.spec :as auth-spec]))
+            [villagebook.user.spec :as user-spec]))
 
 (defn signup
   [{userdata :params :as request}]
-  (if (auth-spec/valid-signup-details? userdata)
+  (if (user-spec/valid-signup-details? userdata)
     (let [message       (models/create-user userdata)
           email         (get-in message [:success :email])
           error         (:error message)
@@ -28,7 +28,7 @@
 
 (defn login
   [{userdata :params :as request}]
-  (if (auth-spec/valid-login-details? userdata)
+  (if (user-spec/valid-login-details? userdata)
     (let [{:keys [email password]} userdata
           message (models/get-token email password)
           token   (get-in message [:success :token])

--- a/src/clj/villagebook/user/models.clj
+++ b/src/clj/villagebook/user/models.clj
@@ -16,8 +16,8 @@
 (defn get-token
   [email password]
   (let [user  (db/get-by-email email)
-        {hashed-password :password db-email :email} user
-        token (jwt/sign {:user db-email} (config/jwt-secret))]
+        {hashed-password :password db-email :email id :id} user
+        token (jwt/sign {:email db-email :id id} (config/jwt-secret))]
 
     (if user
       (if (hasher/check password hashed-password)

--- a/src/clj/villagebook/user/models.clj
+++ b/src/clj/villagebook/user/models.clj
@@ -1,9 +1,9 @@
-(ns villagebook.auth.models
+(ns villagebook.user.models
   (:require [buddy.hashers :as hasher]
             [buddy.auth :refer [authenticated? throw-unauthorized]]
             [buddy.sign.jwt :as jwt]
 
-            [villagebook.auth.db :as db]
+            [villagebook.user.db :as db]
             [villagebook.config :as config]))
 
 (defn create-user
@@ -12,7 +12,6 @@
     (let [user (db/create userdata)]
       {:success user})
     {:error "User with this email already exists."}))
-
 
 (defn get-token
   [email password]

--- a/src/clj/villagebook/user/spec.clj
+++ b/src/clj/villagebook/user/spec.clj
@@ -1,8 +1,7 @@
-(ns villagebook.auth.spec
+(ns villagebook.user.spec
   (:require [villagebook.utils :refer [email-pattern required]]
-            [villagebook.auth.db :as db]
+            [villagebook.user.db :as db]
             [clojure.spec.alpha :as s]))
-
 
 (defn email?
   [value]

--- a/src/clj/villagebook/web.clj
+++ b/src/clj/villagebook/web.clj
@@ -13,18 +13,24 @@
 
             [villagebook.middleware :refer [ignore-trailing-slash]]
             [villagebook.routes :refer [routes]]
-            [villagebook.config :as config]))
+            [villagebook.config :as config]
+            [villagebook.auth.core :as auth]))
 
 ;; Setup handler with the routes
 (def handler
   (make-handler routes))
 
+;; Setup auth backend
+(defn auth-backend
+  []
+  (auth/custom-backend config/auth-config))
+
 ;; Setup all middleware on the handler
 (defn app-handler
   []
   (-> handler
-      (wrap-authentication (config/auth-backend))
-      (wrap-authorization (config/auth-backend))
+      (wrap-authentication (auth-backend))
+      (wrap-authorization (auth-backend))
       wrap-cookies
       ignore-trailing-slash
       wrap-keyword-params

--- a/test/clj/villagebook/auth/core_test.clj
+++ b/test/clj/villagebook/auth/core_test.clj
@@ -1,11 +1,11 @@
-(ns villagebook.auth.backend-tests
+(ns villagebook.auth.core-test
   (:require [buddy.sign.jwt :as jwt]
             [buddy.auth :refer [authenticated?]]
             [buddy.auth.middleware :refer [wrap-authentication]]
 
             [villagebook.fixtures :refer [setup-once wrap-transaction]]
-            [villagebook.auth.backend :as backend]
             [villagebook.config :as config]
+            [villagebook.web :as web]
             [clojure.test :refer :all]))
 
 (use-fixtures :once setup-once)
@@ -31,14 +31,14 @@
 (deftest custom-backend-tests
   (testing "Token backend authentication - in header"
     (let [request (make-header-request jwt-data (config/jwt-secret))
-          handler (wrap-authentication identity (config/auth-backend))
+          handler (wrap-authentication identity (web/auth-backend))
           request' (handler request)]
       (is (authenticated? request'))
       (is (= (:identity request') jwt-data))))
 
   (testing "Token backend authentication - in cookie"
     (let [request (make-cookie-request jwt-data (config/jwt-secret))
-          handler (wrap-authentication identity (config/auth-backend))
+          handler (wrap-authentication identity (web/auth-backend))
           request' (handler request)]
       (is (authenticated? request'))
       (is (= (:identity request') jwt-data)))))

--- a/test/clj/villagebook/organisation/db_test.clj
+++ b/test/clj/villagebook/organisation/db_test.clj
@@ -43,11 +43,16 @@
       (is (= permission "none")))))
 
 (deftest retrieve-tests
-  (testing "Should retrieve list of all organisations"
-    (let [{id :id}      (db/create! factory/organisation)
-          required-keys (keys factory/organisation)]
-      (is (= factory/organisation (-> (db/retrieve id)
-                                      (select-keys required-keys)))))))
+ (let [{id :id}      (db/create! factory/organisation)
+       required-keys (keys factory/organisation)]
+   (testing "Should retrieve organisation by id"
+     (is (= factory/organisation (-> (db/retrieve id)
+                                     (select-keys required-keys)))))
+
+   (testing "Should retrieve list of all organisations"
+     (is (= factory/organisation (-> (db/retrieve)
+                                     first
+                                     (select-keys required-keys)))))))
 
 (deftest retrieve-by-user-tests
   (testing "Should retrieve list of user's organisations with permissions"

--- a/test/clj/villagebook/organisation/db_test.clj
+++ b/test/clj/villagebook/organisation/db_test.clj
@@ -44,17 +44,17 @@
 
 (deftest retrieve-tests
   (testing "Should retrieve list of all organisations"
-    (let [{id :id} (db/create! factory/organisation)]
-      (is (= (factory/organisation (-> (db/retrieve id)
-                                       (dissoc :id :created_at)
-                                       first)))))))
+    (let [{id :id}      (db/create! factory/organisation)
+          required-keys (keys factory/organisation)]
+      (is (= factory/organisation (-> (db/retrieve id)
+                                      (select-keys required-keys)))))))
 
 (deftest retrieve-by-user-tests
   (testing "Should retrieve list of user's organisations with permissions"
-    (let [{user-id :user-id}       (user-db/create factory/user1)
-          {org-id :org-id}         (db/create! factory/organisation)
-          {permission :permission} (db/add-user-as! org-id user-id "member")]
-      (is (= (factory/organisation (-> (db/retrieve-by-user user-id)
-                                       (first)
-                                       (dissoc :id :created_at)
-                                       (assoc :permission "member"))))))))
+    (let [{user-id :id}            (user-db/create factory/user1)
+          {org-id :id}             (db/create! factory/organisation)
+          {permission :permission} (db/add-user-as! org-id user-id "member")
+          required-keys            (keys factory/organisation)]
+      (is (= factory/organisation (-> (db/retrieve-by-user user-id)
+                                      first
+                                      (select-keys required-keys)))))))

--- a/test/clj/villagebook/organisation/db_test.clj
+++ b/test/clj/villagebook/organisation/db_test.clj
@@ -18,28 +18,29 @@
   (testing "Should make the user owner of the organisation"
     (let [{user-id :user-id}       (user-db/create factory/user1)
           {org-id :org-id}         (db/create! factory/organisation)
-          {permission :permission} (db/add-user-as! org-id user-id "owner")]
+          {permission :permission} (db/add-user-as! org-id user-id :owner)]
         (is (= permission "owner")))))
 
 (deftest add-user-as-member-tests
   (testing "Should make the user member of the organisation"
     (let [{user-id :user-id}       (user-db/create factory/user1)
           {org-id :org-id}         (db/create! factory/organisation)
-          {permission :permission} (db/add-user-as! org-id user-id "member")]
+          {permission :permission} (db/add-user-as! org-id user-id :member)]
       (is (= permission "member")))))
 
 (deftest add-user-as-none-tests
   (testing "Should set permission to none"
     (let [{user-id :user-id}       (user-db/create factory/user1)
           {org-id :org-id}         (db/create! factory/organisation)
-          {permission :permission} (db/add-user-as! org-id user-id "none")]
+          {permission :permission} (db/add-user-as! org-id user-id :none)]
         (is (= permission "none")))))
 
 (deftest add-user-as-invalid-tests
   (testing "Should fail on roles other than in the enum"
-    (let [{user-id :user-id} (user-db/create factory/user1)
-          {org-id :org-id}   (db/create! factory/organisation)]
-      (is (thrown? Exception (db/add-user-as! org-id user-id "make-me-owner!"))))))
+    (let [{user-id :user-id}       (user-db/create factory/user1)
+          {org-id :org-id}         (db/create! factory/organisation)
+          {permission :permission} (db/add-user-as! org-id user-id "make-me-owner!")]
+      (is (= permission "none")))))
 
 (deftest retrieve-tests
   (testing "Should retrieve list of all organisations"

--- a/test/clj/villagebook/organisation/db_test.clj
+++ b/test/clj/villagebook/organisation/db_test.clj
@@ -1,14 +1,42 @@
 (ns villagebook.organisation.db-test
   (:require [villagebook.fixtures :refer [setup-once wrap-transaction]]
-            [villagebook.organisation.db :as sut]
+            [villagebook.user.db :as user-db]
+            [villagebook.organisation.db :as db]
             [villagebook.factory :as factory]
             [clojure.test :refer :all]))
 
 (use-fixtures :once setup-once)
 (use-fixtures :each wrap-transaction)
 
-(deftest create-organisation
+(deftest create-tests
   (testing "Should create an organisation"
-    (let [{:keys [id]} (sut/create factory/organisation)]
-      (is (= factory/organisation (-> (sut/get-by-id id)
-                                    (dissoc :id :created_at)))))))
+    (let [{:keys [id]} (db/create! factory/organisation)]
+      (is (= factory/organisation (-> (db/get-by-id id)
+                                      (dissoc :id :created_at)))))))
+
+(deftest add-user-as-owner-tests
+  (testing "Should make the user owner of the organisation"
+    (let [{user-id :user-id} (user-db/create factory/user1)
+          {org-id :org-id}   (db/create! factory/organisation)
+          permission         (db/add-user-as! org-id user-id "owner")]
+        (is (= (:permission permission) "owner")))))
+
+(deftest add-user-as-member-tests
+  (testing "Should make the user member of the organisation"
+    (let [{user-id :user-id} (user-db/create factory/user1)
+          {org-id :org-id}   (db/create! factory/organisation)
+          permission         (db/add-user-as! org-id user-id "member")]
+      (is (= (:permission permission) "member")))))
+
+(deftest add-user-as-none-tests
+  (testing "Should set permission to none"
+    (let [{user-id :user-id} (user-db/create factory/user1)
+          {org-id :org-id}   (db/create! factory/organisation)
+          permission         (db/add-user-as! org-id user-id "none")]
+        (is (= (:permission permission) "none")))))
+
+(deftest add-user-as-invalid-tests
+  (testing "Should fail on roles other than in the enum"
+    (let [{user-id :user-id} (user-db/create factory/user1)
+          {org-id :org-id}   (db/create! factory/organisation)]
+      (is (thrown? Exception (db/add-user-as! org-id user-id "make-me-owner!"))))))

--- a/test/clj/villagebook/organisation/handlers_test.clj
+++ b/test/clj/villagebook/organisation/handlers_test.clj
@@ -13,4 +13,4 @@
           response (handlers/create! request)]
       (is (= 201 (:status response)))
       (is (= (:name factory/organisation) (get-in response [:body :name])))
-      (is (not (empty? (handlers/get-by-id (get-in response [:body :id]))))))))
+      (is (not (empty? (handlers/retrieve (get-in response [:body :id]))))))))

--- a/test/clj/villagebook/organisation/handlers_test.clj
+++ b/test/clj/villagebook/organisation/handlers_test.clj
@@ -1,16 +1,16 @@
 (ns villagebook.organisation.handlers-test
   (:require [villagebook.fixtures :refer [setup-once wrap-transaction]]
-            [villagebook.organisation.handlers :as sut]
+            [villagebook.organisation.handlers :as handlers]
             [villagebook.factory :as factory]
             [clojure.test :refer :all]))
 
 (use-fixtures :once setup-once)
 (use-fixtures :each wrap-transaction)
 
-(deftest create-organisation
+(deftest create-tests
   (testing "Creating an organisation and checking if it was created."
      (let [request {:params factory/organisation}
-          response (sut/create-organisation request)]
+          response (handlers/create! request)]
       (is (= 201 (:status response)))
       (is (= (:name factory/organisation) (get-in response [:body :name])))
-      (is (not (empty? (sut/get-by-id (get-in response [:body :id]))))))))
+      (is (not (empty? (handlers/get-by-id (get-in response [:body :id]))))))))

--- a/test/clj/villagebook/organisation/handlers_test.clj
+++ b/test/clj/villagebook/organisation/handlers_test.clj
@@ -1,5 +1,6 @@
 (ns villagebook.organisation.handlers-test
   (:require [villagebook.fixtures :refer [setup-once wrap-transaction]]
+            [villagebook.organisation.db :as db]
             [villagebook.organisation.handlers :as handlers]
             [villagebook.factory :as factory]
             [clojure.test :refer :all]))
@@ -9,8 +10,17 @@
 
 (deftest create-tests
   (testing "Creating an organisation and checking if it was created."
-     (let [request {:params factory/organisation}
+    (let [request {:params factory/organisation}
           response (handlers/create! request)]
       (is (= 201 (:status response)))
+      (is (= (:name factory/organisation) (get-in response [:body :name])))
+      (is (not (empty? (handlers/retrieve (get-in response [:body :id]))))))))
+
+(deftest retrieve-tests
+  (testing "Retrieving an organisation"
+    (let [{id :id} (db/create! factory/organisation)
+          request  {:params {:id (str id)}}
+          response  (handlers/retrieve request)]
+      (is (= 200 (:status response)))
       (is (= (:name factory/organisation) (get-in response [:body :name])))
       (is (not (empty? (handlers/retrieve (get-in response [:body :id]))))))))

--- a/test/clj/villagebook/organisation/models_test.clj
+++ b/test/clj/villagebook/organisation/models_test.clj
@@ -1,0 +1,16 @@
+(ns villagebook.organisation.models-test
+  (:require [villagebook.fixtures :refer [setup-once wrap-transaction]]
+            [villagebook.user.db :as user-db]
+            [villagebook.organisation.db :as db]
+            [villagebook.organisation.models :as models]
+            [clojure.test :refer :all]
+            [villagebook.factory :as factory]))
+
+(use-fixtures :once setup-once)
+(use-fixtures :each wrap-transaction)
+
+(deftest create-test
+  (testing "Should create an organisation and add a user as owner"
+    (let [{user-id :id}      (user-db/create factory/user1)
+          {orgdata :success} (models/create! factory/organisation user-id)]
+      (is (= factory/organisation (dissoc orgdata :created_at :id))))))

--- a/test/clj/villagebook/organisation/models_test.clj
+++ b/test/clj/villagebook/organisation/models_test.clj
@@ -14,3 +14,12 @@
     (let [{user-id :id}      (user-db/create factory/user1)
           {orgdata :success} (models/create! factory/organisation user-id)]
       (is (= factory/organisation (dissoc orgdata :created_at :id))))))
+
+(deftest retrieve-test
+  (testing "Should retrieve an organisation given it's id"
+    (let [{org-id :id}       (db/create! factory/organisation)
+          {orgdata :success} (models/retrieve org-id)]
+      (is (= factory/organisation (dissoc orgdata :created_at :id)))))
+  (testing "Should return an error map if organisation does not exist"
+    (let [{error :error} (models/retrieve 0)]
+      (is error))))

--- a/test/clj/villagebook/organisation/models_test.clj
+++ b/test/clj/villagebook/organisation/models_test.clj
@@ -12,14 +12,22 @@
 (deftest create-test
   (testing "Should create an organisation and add a user as owner"
     (let [{user-id :id}      (user-db/create factory/user1)
-          {orgdata :success} (models/create! factory/organisation user-id)]
-      (is (= factory/organisation (dissoc orgdata :created_at :id))))))
+          {orgdata :success} (models/create! factory/organisation user-id)
+          test-org           (-> factory/organisation
+                                 (assoc :user_id user-id)
+                                 (assoc :permission "owner"))
+          required-keys      (keys test-org)
+          new-org            (-> (db/retrieve-by-user user-id)
+                                 first
+                                 (select-keys required-keys))]
+      (is (= test-org new-org)))))
 
 (deftest retrieve-test
   (testing "Should retrieve an organisation given it's id"
     (let [{org-id :id}       (db/create! factory/organisation)
           {orgdata :success} (models/retrieve org-id)]
       (is (= factory/organisation (dissoc orgdata :created_at :id)))))
+
   (testing "Should return an error map if organisation does not exist"
     (let [{error :error} (models/retrieve 0)]
       (is error))))

--- a/test/clj/villagebook/user/db_test.clj
+++ b/test/clj/villagebook/user/db_test.clj
@@ -1,7 +1,7 @@
-(ns villagebook.auth.db-test
+(ns villagebook.user.db-test
   (:require [villagebook.fixtures :refer [setup-once wrap-transaction]]
             [villagebook.factory :refer [user1 user2]]
-            [villagebook.auth.db :as auth-db]
+            [villagebook.user.db :as db]
             [clojure.test :refer :all]))
 
 (use-fixtures :once setup-once)
@@ -9,9 +9,9 @@
 
 (deftest create-and-get-user-test
   (testing "Creating and getting a user in DB."
-    (let [user (auth-db/create user1)
+    (let [user (db/create user1)
           email (:email user)
           user-details (dissoc user1 :password)
-          created-user (auth-db/get-by-email email)
+          created-user (db/get-by-email email)
           created-user-details (apply dissoc created-user [:password :created_at :id])]
       (is (= user-details created-user-details)))))

--- a/test/clj/villagebook/user/handlers_test.clj
+++ b/test/clj/villagebook/user/handlers_test.clj
@@ -71,6 +71,6 @@
           email    (:email user1)
           password (:password user1)
           message  (models/get-token email password)
-          request  {:identity {:user email}}
+          request  {:identity {:email email}}
           response (handlers/retrieve request)]
       (is (= 200 (:status response))))))

--- a/test/clj/villagebook/user/handlers_test.clj
+++ b/test/clj/villagebook/user/handlers_test.clj
@@ -1,9 +1,9 @@
-(ns villagebook.auth.handlers-test
+(ns villagebook.user.handlers-test
   (:require [villagebook.fixtures :refer [setup-once wrap-transaction]]
             [villagebook.factory :refer [user1 user2]]
-            [villagebook.auth.db :as auth-db]
-            [villagebook.auth.handlers :as auth-handlers]
-            [villagebook.auth.models :as auth-models]
+            [villagebook.user.db :as db]
+            [villagebook.user.models :as models]
+            [villagebook.user.handlers :as handlers]
             [clojure.test :refer :all]))
 
 (use-fixtures :once setup-once)
@@ -12,65 +12,65 @@
 (deftest signup-tests
   (testing "Signing up"
     (let [request  {:params user1}
-          response (auth-handlers/signup request)]
+          response (handlers/signup request)]
       (is (= 201 (:status response)))
       (is (= (:email user1) (get-in response [:body :email])))
       (is (get-in response [:body :token]))
       (is (get-in response [:cookies "token" :value]))
-      (is (not (empty? (auth-db/get-by-email (get-in response [:body :email])))))))
+      (is (not (empty? (db/get-by-email (get-in response [:body :email])))))))
 
   (testing "Signing up as user 2 (with optional details)"
     (let [request  {:params user2}
-          response (auth-handlers/signup request)]
+          response (handlers/signup request)]
       (is (= 201 (:status response)))
       (is (= (:email user2) (get-in response [:body :email])))
       (is (get-in response [:body :token]))
       (is (get-in response [:cookies "token" :value]))
-      (is (not (empty? (auth-db/get-by-email (get-in response [:body :email]))))))))
+      (is (not (empty? (db/get-by-email (get-in response [:body :email]))))))))
 
 (deftest invalid-signup-tests
   (testing "Signing up with invalid request"
     (let [request  {}
-          response (auth-handlers/signup request)]
+          response (handlers/signup request)]
       (is (= 400 (:status response))))))
 
 (deftest login-tests
   (testing "Logging in as user 1"
-    (let [user (auth-db/create user1)
+    (let [user (db/create user1)
           request  {:params user1}
-          response (auth-handlers/login request)]
+          response (handlers/login request)]
       (is (= 200 (:status response)))
       (is (not (nil? (get-in response [:body :token]))))
       (is (get-in response [:cookies "token" :value])))))
 
 (deftest invalid-login-tests
-  (let [user (auth-db/create user1)]
+  (let [user (db/create user1)]
   (testing "Logging in with invalid request"
     (let [request  {}
-          response (auth-handlers/login request)]
+          response (handlers/login request)]
         (is (= 400 (:status response)))))
 
   (testing "Logging in with invalid request - missing password"
     (let [request  {:params (dissoc user1 :password)}
-          response (auth-handlers/login request)]
+          response (handlers/login request)]
       (is (= 400 (:status response)))))
 
   (testing "Logging in as user 1 with incorrect password"
     (let [request  {:params (assoc user1 :password "wrongpassword")}
-          response (auth-handlers/login request)]
+          response (handlers/login request)]
         (is (= 401 (:status response)))))
 
   (testing "Logging in with invalid email (does not exist)"
     (let [request  {:params (assoc user1 :email "random@example.org")}
-          response (auth-handlers/login request)]
+          response (handlers/login request)]
         (is (= 401 (:status response)))))))
 
 (deftest retrieve-tests
   (testing "Retrieving a user."
-    (let [user     (auth-db/create user1)
+    (let [user     (db/create user1)
           email    (:email user1)
           password (:password user1)
-          message  (auth-models/get-token email password)
+          message  (models/get-token email password)
           request  {:identity {:user email}}
-          response (auth-handlers/retrieve request)]
+          response (handlers/retrieve request)]
       (is (= 200 (:status response))))))


### PR DESCRIPTION
Created against #8 for reviews only. Merge #8 before this.
(Note to self: change target to master before merging.)

The permission levels are:
- owner (read, write, invite)
- member (read, write)
- none (inactive, removed from organisation)

By default, user is added as an owner when they create an organisation.