### PR TITLE
Rename/refactor backend user functions

### DIFF
--- a/src/clj/villagebook/organisation/handlers.clj
+++ b/src/clj/villagebook/organisation/handlers.clj
@@ -20,8 +20,8 @@
 
 (defn- retrieve-from-model
   [id]
-  (let [message        (models/retrieve 55)
-        {org :success}  message
+  (let [message        (models/retrieve id)
+        {org :success} message
         {error :error} message]
     (if org
       (res/response org)

--- a/src/clj/villagebook/user/db.clj
+++ b/src/clj/villagebook/user/db.clj
@@ -6,16 +6,8 @@
 
             [villagebook.config :as config]))
 
-(defn get-by-email
-  "Fetches user by email. Returns nil if not found."
-  [email]
-  (-> (jdbc/query (config/db-spec) (-> (honey/select :*)
-                                     (honey/from :users)
-                                     (honey/where [:= :email email])
-                                     sql/format))
-      first))
 
-(defn create
+(defn create!
   "Creates a user with given fields."
   [userdata]
   (let [hashed-pass (hasher/derive (:password userdata))]
@@ -24,3 +16,17 @@
                                              :password hashed-pass
                                              :name     (:name userdata)})
         first)))
+
+(defn retrieve
+  "Fetches user by id. Return nil if not found."
+  [id]
+  (jdbc/get-by-id (config/db-spec) :users id))
+
+(defn retrieve-by-email
+  "Fetches user by email. Returns nil if not found."
+  [email]
+  (-> (jdbc/query (config/db-spec) (-> (honey/select :*)
+                                     (honey/from :users)
+                                     (honey/where [:= :email email])
+                                     sql/format))
+      first))

--- a/src/clj/villagebook/user/db.clj
+++ b/src/clj/villagebook/user/db.clj
@@ -9,13 +9,15 @@
 
 (defn create!
   "Creates a user with given fields."
-  [userdata]
-  (let [hashed-pass (hasher/derive (:password userdata))]
-    (-> (jdbc/insert! (config/db-spec) :users {:nickname (:nickname userdata)
-                                             :email    (:email userdata)
-                                             :password hashed-pass
-                                             :name     (:name userdata)})
-        first)))
+  ([userdata]
+   (create! (config/db-spec) userdata))
+  ([db-spec userdata]
+   (let [hashed-pass (hasher/derive (:password userdata))]
+     (-> (jdbc/insert! db-spec :users {:nickname (:nickname userdata)
+                                       :email    (:email userdata)
+                                       :password hashed-pass
+                                       :name     (:name userdata)})
+         first))))
 
 (defn retrieve
   "Fetches user by id. Return nil if not found."
@@ -24,9 +26,11 @@
 
 (defn retrieve-by-email
   "Fetches user by email. Returns nil if not found."
-  [email]
-  (-> (jdbc/query (config/db-spec) (-> (honey/select :*)
-                                     (honey/from :users)
-                                     (honey/where [:= :email email])
-                                     sql/format))
-      first))
+  ([email]
+   (retrieve-by-email (config/db-spec) email))
+  ([db-spec email]
+   (-> (jdbc/query (config/db-spec) (-> (honey/select :*)
+                                        (honey/from :users)
+                                        (honey/where [:= :email email])
+                                        sql/format))
+       first)))

--- a/src/clj/villagebook/user/handlers.clj
+++ b/src/clj/villagebook/user/handlers.clj
@@ -12,7 +12,7 @@
 (defn signup
   [{userdata :params :as request}]
   (if (user-spec/valid-signup-details? userdata)
-    (let [message       (models/create-user userdata)
+    (let [message       (models/create! userdata)
           email         (get-in message [:success :email])
           error         (:error message)
           password      (:password userdata)
@@ -42,8 +42,8 @@
 
 (defn retrieve
   [{identity :identity :as request}]
-  (if-let [user (:email identity)]
-    (if-let [userdata (models/get-by-email user)]
+  (if-let [user-id (:id identity)]
+    (if-let [userdata (models/retrieve user-id)]
       (res/response userdata)
       (-> (res/response "Something went wrong.")
           (res/status 500)))

--- a/src/clj/villagebook/user/models.clj
+++ b/src/clj/villagebook/user/models.clj
@@ -6,25 +6,29 @@
             [villagebook.user.db :as db]
             [villagebook.config :as config]))
 
-(defn create-user
-  [{:keys [email] :as userdata}]
-  (if-not (db/get-by-email email)
-    (let [user (db/create userdata)]
+(defn create!
+  [{:keys [id] :as userdata}]
+  (if-not (db/retrieve id)
+    (let [user (db/create! userdata)]
       {:success user})
     {:error "User with this email already exists."}))
 
 (defn get-token
   [email password]
-  (let [user  (db/get-by-email email)
-        {hashed-password :password db-email :email id :id} user
-        token (jwt/sign {:email db-email :id id} (config/jwt-secret))]
-
-    (if user
+  (let [{hashed-password :password
+         db-email        :email
+         id              :id} (db/retrieve-by-email email)
+        token    (jwt/sign {:email db-email :id id} (config/jwt-secret))]
+    (if id
       (if (hasher/check password hashed-password)
         {:success {:token token}}
         {:error "Invalid password"})
       {:error "Email not found"})))
 
-(defn get-by-email
+(defn retrieve
+  [id]
+  (dissoc (db/retrieve id) :password :created_at :id))
+
+(defn retrieve-by-email
   [email]
-  (dissoc (db/get-by-email email) :password :created_at :id))
+  (dissoc (db/retrieve-by-email email) :password :created_at :id))

--- a/test/clj/villagebook/organisation/db_test.clj
+++ b/test/clj/villagebook/organisation/db_test.clj
@@ -16,31 +16,32 @@
 
 (deftest add-user-as-owner-tests
   (testing "Should make the user owner of the organisation"
-    (let [{user-id :user-id}       (user-db/create factory/user1)
+    (let [{user-id :user-id}       (user-db/create! factory/user1)
           {org-id :org-id}         (db/create! factory/organisation)
           {permission :permission} (db/add-user-as! org-id user-id :owner)]
         (is (= permission "owner")))))
 
 (deftest add-user-as-member-tests
   (testing "Should make the user member of the organisation"
-    (let [{user-id :user-id}       (user-db/create factory/user1)
+    (let [{user-id :user-id}       (user-db/create! factory/user1)
           {org-id :org-id}         (db/create! factory/organisation)
           {permission :permission} (db/add-user-as! org-id user-id :member)]
       (is (= permission "member")))))
 
 (deftest add-user-as-none-tests
   (testing "Should set permission to none"
-    (let [{user-id :user-id}       (user-db/create factory/user1)
+    (let [{user-id :user-id}       (user-db/create! factory/user1)
           {org-id :org-id}         (db/create! factory/organisation)
           {permission :permission} (db/add-user-as! org-id user-id :none)]
         (is (= permission "none")))))
 
 (deftest add-user-as-invalid-tests
   (testing "Should fail on roles other than in the enum"
-    (let [{user-id :user-id}       (user-db/create factory/user1)
+    (let [{user-id :user-id}       (user-db/create! factory/user1)
           {org-id :org-id}         (db/create! factory/organisation)
           {permission :permission} (db/add-user-as! org-id user-id "make-me-owner!")]
       (is (= permission "none")))))
+
 
 (deftest retrieve-tests
  (let [{id :id}      (db/create! factory/organisation)
@@ -56,7 +57,7 @@
 
 (deftest retrieve-by-user-tests
   (testing "Should retrieve list of user's organisations with permissions"
-    (let [{user-id :id}            (user-db/create factory/user1)
+    (let [{user-id :id}            (user-db/create! factory/user1)
           {org-id :id}             (db/create! factory/organisation)
           {permission :permission} (db/add-user-as! org-id user-id "member")
           required-keys            (keys factory/organisation)]

--- a/test/clj/villagebook/organisation/models_test.clj
+++ b/test/clj/villagebook/organisation/models_test.clj
@@ -11,7 +11,7 @@
 
 (deftest create-test
   (testing "Should create an organisation and add a user as owner"
-    (let [{user-id :id}      (user-db/create factory/user1)
+    (let [{user-id :id}      (user-db/create! factory/user1)
           {orgdata :success} (models/create! factory/organisation user-id)
           test-org           (-> factory/organisation
                                  (assoc :user_id user-id)

--- a/test/clj/villagebook/user/db_test.clj
+++ b/test/clj/villagebook/user/db_test.clj
@@ -9,9 +9,9 @@
 
 (deftest create-and-get-user-test
   (testing "Creating and getting a user in DB."
-    (let [user (db/create user1)
+    (let [user (db/create! user1)
           email (:email user)
           user-details (dissoc user1 :password)
-          created-user (db/get-by-email email)
+          created-user (db/retrieve-by-email email)
           created-user-details (apply dissoc created-user [:password :created_at :id])]
       (is (= user-details created-user-details)))))

--- a/test/clj/villagebook/user/handlers_test.clj
+++ b/test/clj/villagebook/user/handlers_test.clj
@@ -17,7 +17,7 @@
       (is (= (:email user1) (get-in response [:body :email])))
       (is (get-in response [:body :token]))
       (is (get-in response [:cookies "token" :value]))
-      (is (not (empty? (db/get-by-email (get-in response [:body :email])))))))
+      (is (not (empty? (db/retrieve-by-email (get-in response [:body :email])))))))
 
   (testing "Signing up as user 2 (with optional details)"
     (let [request  {:params user2}
@@ -26,7 +26,7 @@
       (is (= (:email user2) (get-in response [:body :email])))
       (is (get-in response [:body :token]))
       (is (get-in response [:cookies "token" :value]))
-      (is (not (empty? (db/get-by-email (get-in response [:body :email]))))))))
+      (is (not (empty? (db/retrieve-by-email (get-in response [:body :email]))))))))
 
 (deftest invalid-signup-tests
   (testing "Signing up with invalid request"
@@ -36,7 +36,7 @@
 
 (deftest login-tests
   (testing "Logging in as user 1"
-    (let [user (db/create user1)
+    (let [user (db/create! user1)
           request  {:params user1}
           response (handlers/login request)]
       (is (= 200 (:status response)))
@@ -44,7 +44,7 @@
       (is (get-in response [:cookies "token" :value])))))
 
 (deftest invalid-login-tests
-  (let [user (db/create user1)]
+  (let [user (db/create! user1)]
   (testing "Logging in with invalid request"
     (let [request  {}
           response (handlers/login request)]
@@ -67,10 +67,10 @@
 
 (deftest retrieve-tests
   (testing "Retrieving a user."
-    (let [user     (db/create user1)
+    (let [user     (db/create! user1)
           email    (:email user1)
           password (:password user1)
           message  (models/get-token email password)
-          request  {:identity {:email email}}
+          request  {:identity {:id (:id user)}}
           response (handlers/retrieve request)]
       (is (= 200 (:status response))))))

--- a/test/clj/villagebook/user/models_test.clj
+++ b/test/clj/villagebook/user/models_test.clj
@@ -11,13 +11,13 @@
 
 (deftest create-user-test
   (testing "Creating a user."
-    (let [message (models/create-user user1)
+    (let [message (models/create! user1)
           email (get-in message [:success :email])]
       (is email)
-      (is (not (empty? (db/get-by-email email)))))))
+      (is (not (empty? (db/retrieve-by-email email)))))))
 
 (deftest getting-token-test
-  (let [user (db/create user1)
+  (let [user (db/create! user1)
         {:keys [email password]} user1]
   (testing "Getting a token for user."
     (let [message (models/get-token email password)
@@ -28,7 +28,7 @@
         (is (authenticated? request))))))
 
 (deftest invalid-getting-token-tests
-  (let [user         (db/create user1)
+  (let [user         (db/create! user1)
         bad-email    "random@example.com"
         bad-password "wrongpassword"
         {:keys [email password]} user1]
@@ -45,8 +45,8 @@
 
 (deftest retrieve-user-tests
   (testing "Retrieving user by email"
-    (let [user (db/create user1)
+    (let [user (db/create! user1)
           email (:email user1)
-          userdata (models/get-by-email email)]
+          userdata (models/retrieve-by-email email)]
       (is (:email userdata))
       (is (= nil (:password userdata))))))


### PR DESCRIPTION
Renames user functions (`get` becomes`retrieve`). 
Raised against #10 for reviews. Change base to master before merging.