### PR TITLE
Deployment fixes

### DIFF
--- a/deployment/deploy.yml
+++ b/deployment/deploy.yml
@@ -2,6 +2,8 @@
 - hosts: all
   remote_user: deploy
   gather_facts: false
+  environment:
+    CONFIG_PROFILE: "production"
   tasks:
     - name: Copy service file
       become: true
@@ -20,7 +22,8 @@
         mode: '0644'
 
     - name: Run villagebook migrations
-      become_user: deploy
+      become: true
+      become_user: postgres
       shell: cd /home/deploy/ && java -jar villagebook-0.1.0-SNAPSHOT-standalone.jar migrate
 
     - name: Start villagebook service

--- a/deployment/deploy.yml
+++ b/deployment/deploy.yml
@@ -15,7 +15,12 @@
       local_action: shell shadow-cljs release villagebookUI
 
     - name: Generate Uberjar on local machine
-      local_action: shell lein uberjar
+      local_action: shell lein do clean, uberjar
+
+    - name: Delete old uberjar
+      file:
+        path: /home/deploy/villagebook-0.1.0-SNAPSHOT-standalone.jar
+        state: absent
 
     - name: Copy uberjar to server
       copy:
@@ -23,6 +28,14 @@
         dest: /home/deploy/
         owner: deploy
         mode: '0644'
+
+    - name: Stop villagebook service
+      become: true
+      systemd:
+        daemon_reload: yes
+        state: stopped
+        name: villagebook
+        enabled: yes
 
     - name: Run villagebook migrations
       become: true

--- a/deployment/deploy.yml
+++ b/deployment/deploy.yml
@@ -11,6 +11,9 @@
         src: "villagebook.service"
         dest: /etc/systemd/system
 
+    - name: Compile frontend app
+      local_action: shell shadow-cljs release villagebookUI
+
     - name: Generate Uberjar on local machine
       local_action: shell lein uberjar
 

--- a/deployment/hosts
+++ b/deployment/hosts
@@ -1,5 +1,5 @@
 [deployment]
-server1 ansible_host=206.189.139.112
+server1 ansible_host=villagebook.nilenso.com
 
 [deployment:vars]
 ansible_python_interpreter=/usr/bin/python3

--- a/deployment/provision.yml
+++ b/deployment/provision.yml
@@ -90,7 +90,7 @@
       become: true
       become_user: postgres
       postgresql_db:
-        name: village_book_db
+        name: villagebook_prod
 
     - name: Install nginx
       apt:

--- a/deployment/villagebook.service
+++ b/deployment/villagebook.service
@@ -5,6 +5,8 @@ Description=villagebook
 ExecStart=/usr/bin/java -jar /home/deploy/villagebook-0.1.0-SNAPSHOT-standalone.jar
 Restart=always
 RestartSec=5
+Environment=HOME=/home/deploy/
+Environment=CONFIG_PROFILE=production
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
Patches to the deployment scripts. Solves:
- Slow startup of the uberjar,
- `java.lang.IllegalArgumentException` being thrown by buddy (because $HOME wasn't set in the env variables, config wasn't able to find .villagebook-secrets.edn)